### PR TITLE
Added info on entering hiyaCFW settings

### DIFF
--- a/_pages/en_US/installing-hiyacfw.md
+++ b/_pages/en_US/installing-hiyacfw.md
@@ -50,7 +50,9 @@ When it says "Done", then you may eject your SD card and insert it into your Nin
 1. Select `hiya.dsi` and press **(A)**
   - This will make the system launch hiyaCFW at boot
 1. Save your settings and restart your console
-1. Change the settings to your liking, and press (START) to continue
+1. Hold **(SELECT)** while powering on your Nintendo DSi console to access the hiyaCFW settings
+  - If you selected `Install latest TWiLight Menu++ on custom firmware` to boot into the SDNAND home screen instead of TWiLight Menu++, navigate to `Autoboot title` and press **(A)** to deselect it.
+1. Change the settings to your liking, and press **(START)** to continue
 
 Your system will now boot from the SD card instead of the internal NAND.
 


### PR DESCRIPTION
I noticed while putting hiyaCFW on my DSi again that there wasn't any information on how to boot to the SDNAND home screen instead of TWiLight Menu++ (If it was chosen when using hiyaCFW Helper). This wasted some time for me as I tried to search up how to do it. Eventually, I turned towards the Nintendo Homebrew Discord server where someone was quickly able to tell me how to resolve my issue. To save this trouble for anyone else, I have made a small change to **"Section II - Configuring Unlaunch and hiyaCFW"** mentioning how to actually open hiyaCFW settings and how to boot to the SDNAND home screen instead of TWiLight Menu++.