### PR TITLE
Replace cfdisk with mkdosfs for 32 KB cluster size

### DIFF
--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -63,7 +63,7 @@ If the test shows any other results, your SD card may be corrupted or damaged an
    <h2>Linux</h2>
 </noscript>
 
-## Section I - Determining which slot your SD card is in and Formatting the card
+## Section I - Formatting your SD card
 1. Make sure your SD card is **not** inserted into your Linux machine
 1. Launch the Linux Terminal
 1. Type `watch "lsblk"`

--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -79,16 +79,8 @@ mmcblk0     179:0    0   3,8G  0 disk
 1. Hit CTRL + C to exit the menu
 
 ## Section II - Formatting the card
-![](https://s.blogcdn.com/www.engadget.com/media/2012/06/cfdisk.jpg)
 
-1. Type in `sudo cfdisk /dev/(device mount point from above)`
-1. On each partition, hit `Delete`
-1. Create a new Primary partition that covers the size of your entire SD card
-- This will create a new partition with the linux filetype
-1. Select type and take a look at the menu
-1. Find `W95 FAT32` and take note of the code on the left side of that text
-1. Press any key, then enter the code you took note of in the previous step
-1. Hit enter, then hit Quit
+1. Type in `sudo mkdosfs /dev/(device mount point from above) -s 64 -F 32 -I` to create a single FAT32 partition with 32 KB cluster size on the SD card
 
 ## Section III - Using F3
 1. Download and extract [the F3 archive](https://github.com/AltraMayor/f3/archive/v7.2.zip) anywhere on your computer.

--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -63,7 +63,7 @@ If the test shows any other results, your SD card may be corrupted or damaged an
    <h2>Linux</h2>
 </noscript>
 
-## Section I - Determining which slot your SD card is in
+## Section I - Determining which slot your SD card is in and Formatting the card
 1. Make sure your SD card is **not** inserted into your Linux machine
 1. Launch the Linux Terminal
 1. Type `watch "lsblk"`
@@ -77,12 +77,9 @@ mmcblk0     179:0    0   3,8G  0 disk
 1. Take note of the device mount point. In our example above, it was `mmcblk0`
    - If `RO` is set to 1, make sure the lock switch is not slid down
 1. Hit CTRL + C to exit the menu
-
-## Section II - Formatting the card
-
 1. Type in `sudo mkdosfs /dev/(device mount point from above) -s 64 -F 32 -I` to create a single FAT32 partition with 32 KB cluster size on the SD card
 
-## Section III - Using F3
+## Section II - Using F3
 1. Download and extract [the F3 archive](https://github.com/AltraMayor/f3/archive/v7.2.zip) anywhere on your computer.
 1. Launch the terminal in the F3 directory
 1. Run `make` to compile F3


### PR DESCRIPTION
I used the cfdisk command found in this document previously, but after an update TwilightMenu++ shows a warning that game loading is slow if the SD card does not have a 32 KB cluster size. Using this mkdosfs command creates a proper 32 KB cluster size FAT32 partition and TwilightMenu++ no longer shows the warning. Games load fine.