### PR TITLE
Switch hardmod guide to the DS-Homebrew Wiki one

### DIFF
--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -70,5 +70,4 @@ Make sure your Nintendo DSi system is well charged before beginning this section
 Your NAND should now be restored.
 
 ## Flashing your NAND backup (Hardmod)
-If you cannot boot to Unlaunch, a hardmod is the only way to restore a NAND backup.<br>
-This is not very well documented. The best guide that currently exists is the `Hardware NAND Mod Guide` section of [Gadorach's DSi Downgrading - The Complete Guide](https://web.archive.org/web/20151102221503/https://gbatemp.net/threads/dsi-downgrading-the-complete-guide.393682/)
+If you cannot boot your Nintendo DSi, a hardmod is the only way to restore a NAND backup. The best guide that currently exists is the Nintendo DSi hardmod guide on [the DS-Homebrew Wiki](https://wiki.ds-homebrew.com/ds-index/hardmod#nintendo-dsi).

--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -70,4 +70,4 @@ Make sure your Nintendo DSi system is well charged before beginning this section
 Your NAND should now be restored.
 
 ## Flashing your NAND backup (Hardmod)
-If you cannot boot your Nintendo DSi, a hardmod is the only way to restore a NAND backup. The best guide that currently exists is the Nintendo DSi hardmod guide on [the DS-Homebrew Wiki](https://wiki.ds-homebrew.com/ds-index/hardmod#nintendo-dsi).
+If you cannot boot your Nintendo DSi, a hardmod is the only way to restore a NAND backup. The best guide that currently exists is the [Nintendo DSi hardmod guide on the DS-Homebrew Wiki](https://wiki.ds-homebrew.com/ds-index/hardmod#nintendo-dsi).


### PR DESCRIPTION
- Switches the hardmod guide to the DS-Homebrew Wiki one instead of the archive.org link of the GBAtemp one
  - The content was mostly adapted from there iirc, but I think some more stuff has been added for safety and such, and it's just generally better since it's not on archive.org
- Also changes `boot to Unlauch` to `boot your Nintendo DSi` because Unlaunch isn't required, you can restore a backup from Memory Pit just fine should you need to