### PR TITLE
Fix Spanish site navigation missing an endcapture

### DIFF
--- a/_pages/es_ES/site-navigation.md
+++ b/_pages/es_ES/site-navigation.md
@@ -11,6 +11,7 @@ sitemap: false
 + [Respaldando el nand](dumping-nand)
 + [Instalando Unlaunch](installing-unlaunch)
 + [Installando hiyaCFW](hiyacfw-setup)
+{% endcapture %}
 <div class="notice--primary">{{ primary-notice | markdownify }}</div>
 
 {% capture second-notice %}


### PR DESCRIPTION
This simply fixes a missing {% endcapture %} in the Spanish translation that's causing the site build to fail﻿
