### PR TITLE
Change `mmcblk0` to `mmcblk0p1`

### DIFF
--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -74,7 +74,7 @@ NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 mmcblk0     179:0    0   3,8G  0 disk
 └─mmcblk0p1 179:1    0   3,7G  0 part /run/media/user/FFFF-FFFF
 ```
-1. Take note of the device mount point. In our example above, it was `mmcblk0`
+1. Take note of the device mount point. In our example above, it was `mmcblk0p1`
    - If `RO` is set to 1, make sure the lock switch is not slid down
 1. Hit CTRL + C to exit the menu
 1. Type in `sudo mkdosfs /dev/(device mount point from above) -s 64 -F 32 -I` to create a single FAT32 partition with 32 KB cluster size on the SD card

--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -77,7 +77,7 @@ mmcblk0     179:0    0   3,8G  0 disk
 1. Take note of the device mount point. In our example above, it was `mmcblk0p1`
    - If `RO` is set to 1, make sure the lock switch is not slid down
 1. Hit CTRL + C to exit the menu
-1. Type in `sudo mkdosfs /dev/(device mount point from above) -s 64 -F 32 -I` to create a single FAT32 partition with 32 KB cluster size on the SD card
+1. Type in `sudo mkdosfs /dev/(device mount point from above) -s 64 -F 32` to create a single FAT32 partition with 32 KB cluster size on the SD card
 
 ## Section II - Using F3
 1. Download and extract [the F3 archive](https://github.com/AltraMayor/f3/archive/v7.2.zip) anywhere on your computer.


### PR DESCRIPTION
Doing `mmcblk0` or `sda` will break MBR, should be `mmcblk0p1` or `sda1`