### PR TITLE
Remove page redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source "https://rubygems.org"
-gem 'jekyll-redirect-from'
 gemspec

--- a/_config.yml
+++ b/_config.yml
@@ -207,7 +207,6 @@ plugins:
   - jekyll-feed
   - jekyll-include-cache
   - jemoji
-  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:

--- a/_pages/en_US/credits.md
+++ b/_pages/en_US/credits.md
@@ -1,7 +1,5 @@
 ---
 title: "Credits"
-redirect_from:
-  - donations
 ---
 
 This is the credits for those who have helped out with the guide website, homebrew, and other things.

--- a/_pages/en_US/dsiware-backups.md
+++ b/_pages/en_US/dsiware-backups.md
@@ -1,11 +1,5 @@
 ---
 title: DSiWare Backups
-redirect_from:
-  - more/dumping-dsiware-from-3ds
-  - more/dumping-dsiware
-  - dsiware
-  - more/installing-dsiware
-  - installing-dsiware
 ---
 
 {% include toc title="DSiWare Backups" %}

--- a/_pages/en_US/dumping-game-cards.md
+++ b/_pages/en_US/dumping-game-cards.md
@@ -1,10 +1,5 @@
 ---
 title: "Dumping Game Cards"
-redirect_from:
-  - /dump-cart
-  - /dump-card
-  - /dump-game
-  - /dumping-cartridges
 ---
 
 This section is for dumping game cards using GodMode9i so they can be played on emulators, flashcards, or your SD card via nds-bootstrap.

--- a/_pages/en_US/dumping-nand.md
+++ b/_pages/en_US/dumping-nand.md
@@ -1,8 +1,5 @@
 ---
 title: Dumping NAND
-redirect_from:
-  - /nand-dump
-  - /dump-nand
 ---
 
 This page is for making a NAND backup, which is a copy of the data on the Nintendo DSi's internal storage. It can be used to set up hiyaCFW and NO$GBA.

--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -1,7 +1,5 @@
 ---
 title: "FAQ"
-redirect_from:
-  - help/faq
 ---
 {% include toc title="Questions" %}
 

--- a/_pages/en_US/installing-hiyacfw.md
+++ b/_pages/en_US/installing-hiyacfw.md
@@ -1,10 +1,5 @@
 ---
 title: Installing hiyaCFW
-redirect_from:
-  - /guide/installing-hiyacfw
-  - /guide/hiyacfw
-  - /hiyacfw
-  - /hiyacfw-setup
 ---
 
 {% include toc title="Table of Contents" %}

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -1,8 +1,5 @@
 ---
 title: "Installing Unlaunch"
-redirect_from:
-  - /guide/installing-unlaunch
-  - /unlaunch
 ---
 
 {% include toc title="Navigation" %}

--- a/_pages/en_US/launching-the-exploit.md
+++ b/_pages/en_US/launching-the-exploit.md
@@ -1,16 +1,5 @@
 ---
 title: Launching the Exploit
-redirect_from:
-  - /exploit-launch
-  - /guide/exploit-launch
-  - /guide/flipnote-lenny
-  - /flipnote-lenny
-  - /installing-twlmenu++
-  - /more/replacing-system-menu
-  - /replacing-system-menu-with-srloader
-  - /replacing-system-menu-with-dsimenu++
-  - /replacing-system-menu-with-twilight-menu++
-  - /replacing-system-menu-with-twlmenu++
 ---
 
 {% include toc title="Instructions" %}

--- a/_pages/en_US/nds-bootstrap-forwarders.md
+++ b/_pages/en_US/nds-bootstrap-forwarders.md
@@ -1,7 +1,5 @@
 ---
 title: "nds-bootstrap forwarders for hiyaCFW"
-redirect_from:
-- /forwarder
 ---
 
 This is an add-on section that involves creating forwarders for nds-bootstrap. This allows you to launch nds roms directly from your SDNAND's System Menu.

--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -1,8 +1,5 @@
 ---
 title: Restoring a NAND backup
-redirect_from:
-  - /guide/restoring-nand
-  - /guide/nand-restore
 ---
 
 {% include toc title="Table of Contents" %}

--- a/_pages/en_US/sd-card-setup.md
+++ b/_pages/en_US/sd-card-setup.md
@@ -1,10 +1,5 @@
 ---
 title: SD Card Setup
-redirect_from:
-  - /f3-(linux)
-  - /h2testw-(windows)
-  - /f3x-(mac)
-  - /sd-prep
 ---
 
 This page is for preparing your SD card for your Nintendo DSi. In the process, we'll format the SD card to a format suitable for the Nintendo DSi and check the card for errors.


### PR DESCRIPTION
Most of the redirects are completely pointless, I can't even find anywhere linking to them, and the redirect plugin doesn't have a good way to handle translations easily (they're all being dumped in the site root) so I think it's best to just drop them.

The only one I think could be worth keeping is https://dsi.cfw.guide/dumping-cartridges as that page was renamed recently, I think it's fine without a redirect though.