### PR TITLE
Add note on first-time language selection in TWLMenu

### DIFF
--- a/_pages/en_US/launching-the-exploit.md
+++ b/_pages/en_US/launching-the-exploit.md
@@ -55,7 +55,7 @@ If the top screen turns green, you do not have TWiLight Menu++'s `BOOT.NDS` on t
 You should now see the Nintendo DSi Splash Screen, which is being shown by TWiLight Menu++.
 
 ## Section III - Configuring TWiLight Menu++
-
+1. When prompted, set your preferred language and region
 1. Once you're in TWiLight Menu++, press SELECT to switch to the DS Classic Menu
 1. Tap the button in the bottom middle to open settings
 1. Use the <kbd class="l">L</kbd> and <kbd class="r">R</kbd> buttons to switch over to the "Misc. Settings" page


### PR DESCRIPTION
A few releases back TWiLight Menu++ (21.0.0) was updated to have a first-time language selection screen. 

This info was added to the relevant page.