### PR TITLE
Various changes to Launching the Exploit and Installing Unlaunch pages

### DIFF
--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -7,8 +7,8 @@ title: "Installing Unlaunch"
 Unlaunch is an exploit that takes place on system boot. This allows it to have higher privileges than normal DSiWare exploits such as Memory Pit, which makes it able to do the following:
 
 - Launching applications at boot (homebrew or DSiWare), with optional button combinations
-- Access to Slot-1, allowing you to dump cartridges and launch incompatible flashcarts
-- Region locks removed on DSi-Enhanced / Exclusive games
+- Access to Slot-1, allowing you to dump Game Cards and launch incompatible flashcards
+- Region locks removed on DSi-Enhanced / Exclusive Game Cards
 - Run old Nintendo DS homebrew via nds-bootstrap-hb
 - Launching DSiWare from the internal SD card
 - Better sound in GBARunner2
@@ -38,11 +38,11 @@ Using a Windows, Linux, or macOS device? Use [Lazy DSi Downloader](lazy-dsi-down
    - If you have already installed Unlaunch and are looking to update it, hold <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while booting and select the `TWiLight Menu++` where `BOOT.NDS` is shown on the bottom screen
 1. Launch TWiLight Menu++ Settings
    - If you haven't changed your theme, follow the steps in the "Launching the Exploit" page. Otherwise, consult the TWiLight Menu++ Manual
-1. Hit <kbd class="l">L</kbd> / <kbd class="r">R</kbd> or <kbd class="face">X</kbd> / <kbd class="face">Y</kbd> until you reach the `Unlaunch Settings` page
+1. Hit <kbd class="l">L</kbd> / <kbd class="r">R</kbd> or <kbd class="face">X</kbd> / <kbd class="face">Y</kbd> until you reach the `Unlaunch settings` page
 1. If you want to change Unlaunch's background image, select `Background` and choose the one you want
    - If you want to create your own Unlaunch background, consult the [DS-Homebrew Wiki page](https://wiki.ds-homebrew.com/twilightmenu/custom-unlaunch-backgrounds)
 1. If you want the Health and Safety screen and DSi Menu music and sounds, then set `Launcher Patches` to `Off`
-   - This will also prevent region locking from being removed
+   - This will also keep the region locking and card whitelist, meaning that some flashcards won't be usable from the DSi Menu
 1. Exit TWiLight Menu++ Settings
 1. In the file navigation menu, launch `Unlaunch DSi Installer`
 1. Select the install option

--- a/_pages/en_US/launching-the-exploit.md
+++ b/_pages/en_US/launching-the-exploit.md
@@ -63,7 +63,7 @@ You should now see the TWiLight Menu++ language selection.
 1. When prompted, set your preferred language and region
 1. Once you're in TWiLight Menu++, press SELECT to switch to the DS Classic Menu
 1. Tap the button in the bottom middle to open settings
-1. Use the <kbd class="l">L</kbd> and <kbd class="r">R</kbd> or <kbd class="face">X</kbd> and <kbd class="face">Y</kbd> buttons to switch over to the "Misc. settings" page
+1. Use the <kbd class="l">L</kbd> / <kbd class="r">R</kbd> or <kbd class="face">X</kbd> / <kbd class="face">Y</kbd> buttons to switch over to the "Misc. settings" page
 1. Switch the "SysNAND Region" entry to your console's region
 1. Switch the "DSiWare Exploit" entry to Memory Pit
    - If you're using a different exploit, select that instead

--- a/_pages/en_US/launching-the-exploit.md
+++ b/_pages/en_US/launching-the-exploit.md
@@ -22,6 +22,7 @@ Using a Windows, Linux or macOS device? Use [Lazy DSi Downloader](lazy-dsi-downl
 ### Memory Pit
 1. Ensure that the Nintendo DSi Camera application does not show the tutorial after launch
    - If it does show, go through it until you're done
+     - If the tutorial crashes as you try to complete it, your Nintendo DSi camera hardware is likely broken in some way. Please use an [alternate exploit](alternate-exploits)
 1. Download the Memory Pit binary for the version and region of your Nintendo DSi system
    - for versions [1.0 - 1.3 (USA, EUR, AUS, JPN)](https://github.com/emiyl/dsi.cfw.guide/raw/master/assets/files/memory_pit/256/pit.bin)
    - for versions [1.4 - 1.4.5 (USA, EUR, AUS, JPN)](https://github.com/emiyl/dsi.cfw.guide/raw/master/assets/files/memory_pit/768_1024/pit.bin)
@@ -44,7 +45,6 @@ For an understanding on why we're doing this, please review the [FAQ](/faq#what-
 
 1. Ensure your SD card is inserted into your Nintendo DSi
 1. Boot your Nintendo DSi and launch the Nintendo DSi Camera application
-   - If the camera on your Nintendo DSi doesn't work, you can still use Memory Pit as long as the tutorial does not appear. If the tutorial appears and crashes as you try to complete it, please use an [alternate exploit](alternate-exploits)
 1. Select the SD Card icon on the top-right
    - If you receive a message saying your SD card isn't inserted, please use another SD card
    - If you receive a message saying that your SD card cannot be used, ensure your SD card is [formatted correctly](sd-card-setup)
@@ -54,13 +54,16 @@ For an understanding on why we're doing this, please review the [FAQ](/faq#what-
 If the top screen turns green, you do not have TWiLight Menu++'s `BOOT.NDS` on the root of your SD card. Follow the [TWiLight Menu++ setup guide](launching-the-exploit#twilight-menu) again
 {: .notice--warning}
 
-You should now see the Nintendo DSi Splash Screen, which is being shown by TWiLight Menu++.
+If you enter the SD card camera album and nothing unusual happens, ensure that you downloaded the correct version of Memory Pit for your version and region, and placed it into the correct folder on your SD card
+{: .notice--warning}
+
+You should now see the TWiLight Menu++ language selection.
 
 ## Section III - Configuring TWiLight Menu++
 1. When prompted, set your preferred language and region
 1. Once you're in TWiLight Menu++, press SELECT to switch to the DS Classic Menu
 1. Tap the button in the bottom middle to open settings
-1. Use the <kbd class="l">L</kbd> and <kbd class="r">R</kbd> buttons to switch over to the "Misc. Settings" page
+1. Use the <kbd class="l">L</kbd> and <kbd class="r">R</kbd> or <kbd class="face">X</kbd> and <kbd class="face">Y</kbd> buttons to switch over to the "Misc. settings" page
 1. Switch the "SysNAND Region" entry to your console's region
 1. Switch the "DSiWare Exploit" entry to Memory Pit
    - If you're using a different exploit, select that instead


### PR DESCRIPTION
Launching the Exploit:
- Moves alternate exploit suggestion up to Section I
- Adds X/Y to TWiLight Menu++ page switching instructions
- Adds notice about nothing unusual happening upon entering the SD card album
- Updates TWiLight Menu++ introduction for language selection screen
- Decapitalizes "settings" in "Misc. settings"
- Changes "and" to "/" in reference to buttons

Installing Unlaunch:
- Clarifies Launcher Patches setting
- Decapitalizes "settings" in "Unlaunch settings"
- Corrects "flashcarts" / "cartridges" to "flashcards" / "Game Cards"
- Clarifies region unlocking feature