### PR TITLE
Uninstalling Unlaunch the better way & others

### DIFF
--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -11,11 +11,12 @@ title: "FAQ"
 ### How do I play Nintendo DS Game Card dumps?
 Playing Game Card dumps on the console requires the use of a flashcard or nds-bootstrap, a program which enables games to be played from the internal SD card by redirecting Slot-1 reads and writes to it.
 - With TWiLight Menu++ you can navigate your SD card to find ROM files to play with nds-bootstrap. The advantages to using TWiLight Menu++ are having a cheat menu, per-game settings, and avoiding the restrictions that forwarders bring. In other words, you can drop your ROM files directly and play without any setup. There is no 39 title limit, neither hiyaCFW or Unlaunch are required and there are no restrictions on SD card free space you can have
-- hiyaCFW users can create forwarders using the instructions on the [DS-Homebrew Wiki](https://wiki.ds-homebrew.com/ds-index/forwarders?tab=tab-dsi-sd-card) for the SDNAND's DSi Menu, but it has some limitations. There is a hard limit of 39 titles, and they are less convenient to make than using TWiLight Menu++
+- hiyaCFW users can create forwarders for the SDNAND's DSi Menu using the [DS Game Forwarders](https://wiki.ds-homebrew.com/ds-index/forwarders?tab=tab-dsi-sd-card) guide on the DS-Homebrew Wiki, but it has some limitations. There is a hard limit of 39 titles, and they are less convenient to make than using TWiLight Menu++
    - If you do not have hiyaCFW and would like to use forwarders, you can follow the [hiyaCFW installation guide](https://wiki.ds-homebrew.com/hiyacfw/installing) on the DS-Homebrew Wiki
 
 ### How do I update my homebrew?
-- **Unlaunch** - Follow the instructions on the [Installing Unlaunch](/installing-unlaunch) page
+- **Unlaunch** - Follow the instructions on the [Installing Unlaunch](installing-unlaunch) page
+  - You do **not** need to uninstall Unlaunch before doing this
 - **hiyaCFW** - Replace `hiya.dsi` on the root of the SD card from the [updated release](https://github.com/RocketRobz/hiyaCFW/releases)
 - **TWiLight Menu++** - Follow the instructions on the [DS-Homebrew Wiki](https://wiki.ds-homebrew.com/twilightmenu/updating-dsi)
 - **nds-bootstrap** - Copy `nds-bootstrap-hb-release.nds` & `nds-bootstrap-release.nds` to the `_nds` folder on the root of your SD card
@@ -36,3 +37,7 @@ Yes, there are a few different methods depending on what you want to change:
 - The safest and simplest method is to simply install TWiLight Menu++, it can use any official language and more without needing NAND modifications
 - If you want to actually change the system region and are using hiyaCFW, you can use Yoti's [hiyalang](https://github.com/Yoti/cli_hiyalang/releases)
 - Lastly, if you want to change the region on the actual system NAND, you can use Mighty Max's [DSi Language Patcher](https://gbatemp.net/threads/release-dsi-language-patcher.582836/)
+
+### What happened to the hiyaCFW installation guide?
+Because hiyaCFW does not serve much functional purpose and was a problematic and confusing part of the guide for many users, it was moved to the [DS-Homebrew Wiki](https://wiki.ds-homebrew.com/hiyacfw/installing).
+- If you were linked to the page in question, the instructions you were following were most likely outdated. Please use this guide instead, as it is maintained constantly by the developers of these projects

--- a/_pages/en_US/faq.md
+++ b/_pages/en_US/faq.md
@@ -40,4 +40,4 @@ Yes, there are a few different methods depending on what you want to change:
 
 ### What happened to the hiyaCFW installation guide?
 Because hiyaCFW does not serve much functional purpose and was a problematic and confusing part of the guide for many users, it was moved to the [DS-Homebrew Wiki](https://wiki.ds-homebrew.com/hiyacfw/installing).
-- If you were linked to the page in question, the instructions you were following were most likely outdated. Please use this guide instead, as it is maintained constantly by the developers of these projects
+- If you were linked to the page in question from another guide, the instructions you were following were most likely outdated. Please use this guide instead, as it is maintained constantly by the developers of these projects

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -10,9 +10,10 @@ Unlaunch is an exploit that takes place on system boot. This allows it to have h
 - Access to Slot-1, allowing you to dump Game Cards and launch incompatible flashcards
 - Region locks removed on DSi-Enhanced / Exclusive Game Cards
 - Run old Nintendo DS homebrew via nds-bootstrap-hb
-- Improved compatibility with DSiWare launched from the SD card
-- Better sound in GBARunner2
 - Brick-protection
+- The following for Memory Pit users (other exploits already allow these):
+     - Improved compatibility with DSiWare launched from the SD card
+     - Better sound in GBARunner2
 
 If you have not yet done so, please follow [Dumping NAND](dumping-nand). While the chances are slim, Unlaunch can accidentally brick your Nintendo DSi. A NAND backup + [hardmod](https://wiki.ds-homebrew.com/ds-index/hardmod) would allow you to restore this backup, provided you know how to solder.
 {: .notice--danger}

--- a/_pages/en_US/installing-unlaunch.md
+++ b/_pages/en_US/installing-unlaunch.md
@@ -10,7 +10,7 @@ Unlaunch is an exploit that takes place on system boot. This allows it to have h
 - Access to Slot-1, allowing you to dump Game Cards and launch incompatible flashcards
 - Region locks removed on DSi-Enhanced / Exclusive Game Cards
 - Run old Nintendo DS homebrew via nds-bootstrap-hb
-- Launching DSiWare from the internal SD card
+- Improved compatibility with DSiWare launched from the SD card
 - Better sound in GBARunner2
 - Brick-protection
 

--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -46,7 +46,7 @@ It is very important to test that your NAND backup is working before attempting 
 5. Click `Options` > `Emulation Setup` to open the Emulation Setup window
 6. Change `Reset/Startup Entrypoint` to `GBA/NDS BIOS (Nintendo logo)`
 7. Change `NDS Mode/Colors` to `DSi (retail/16MB)`
-8. Click `OK`
+8. Click `Save Now`
 9. Launch any Nintendo DS ROM (`.nds` file)
 
 If no$gba loads the DSi menu (or the Unlaunch Filemenu), then continue to the next section. If it shows any kind of error ***do not flash that backup***!

--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -52,14 +52,14 @@ It is very important to test that your NAND backup is working before attempting 
 If no$gba loads the DSi menu (or the Unlaunch Filemenu), then continue to the next section. If it shows any kind of error ***do not flash that backup***!
 
 ## Uninstalling Unlaunch from your NAND backup (optional)
-Follow this if you dumped your NAND backup after you installed Unlaunch and you would like to uninstall Unlaunch from your system.
+Follow this if you dumped your NAND backup after you installed Unlaunch and you would like to uninstall Unlaunch from your system. If you are not trying to uninstall Unlaunch, you do **not** need to do this section.
 1. Download the latest version of the [Unlaunch installer](https://problemkaputt.de/unlaunch.zip)
 1. Extract `UNLAUNCH.DSI` from `unlaunch.zip`
 1. Launch `UNLAUNCH.DSI` in no$gba and start it from the Game Card slot
-- This should start the Unlaunch installer, which looks similar to to the Unlaunch Filemenu
-4. Choose `Uninstall`
-4. Once complete, choose `Power down`
-4. Launch any Nintendo DS ROM again, and ensure your DSi menu loads and is working properly
+   - This should start the Unlaunch installer, which looks similar to to the Unlaunch Filemenu
+1. Choose `Uninstall`
+1. Once complete, choose `Power down`
+1. Launch any Nintendo DS ROM again, and ensure your DSi menu loads and is working properly
 
 ## Flashing your NAND backup (Software)
 

--- a/_pages/en_US/restoring-nand.md
+++ b/_pages/en_US/restoring-nand.md
@@ -15,7 +15,7 @@ First, a few safer alternatives to why you might want to do this:
 - Recovering pictures can be done using [ninfs](https://github.com/ihaveamac/ninfs/releases), in combination with hiyaCFW or TWiLight Menu++ if you want them on console. The latest version of the HiyaCFW Helper allows you to copy your photos from your NAND to the SDNAND during setup
 - Restoring an Unlaunch button configuration can be done from the Unlaunch menu, which can be accessed by holding <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while powering the console on
 - Booting into Unlaunch resulting in an error? Take out your SD card and try starting the system again. If it works, then it's a fault with your SD card and restoring a NAND backup won't fix it
-- "An error has occurred..." on boot is likely a hiyaCFW error and is not related to your NAND, see [hiyaCFW FAQ & Troubleshooting](https://wiki.ds-homebrew.com/hiyacfw/faq) for more information
+- "An error has occurred..." on boot is likely a hiyaCFW error and is not related to your NAND, see [hiyaCFW FAQ & Troubleshooting](https://wiki.ds-homebrew.com/hiyacfw/faq) on the DS-Homebrew Wiki for more information
 - Any errors in TWiLight Menu++ are unrelated and you should try reinstalling TWiLight Menu++ or ask for help on [Discord](https://ds-homebrew.com/discord)
 - Uninstalling Unlaunch, whether by flashing NAND or using its uninstaller, should avoided unless absolutely necessary, you can set the autoboot keys to "Launcher" and your DSi will be like stock
 
@@ -49,7 +49,17 @@ It is very important to test that your NAND backup is working before attempting 
 8. Click `OK`
 9. Launch any Nintendo DS ROM (`.nds` file)
 
-If no$gba loads the DSi menu, then continue to the next section. If it shows any kind of error ***do not flash that backup***!
+If no$gba loads the DSi menu (or the Unlaunch Filemenu), then continue to the next section. If it shows any kind of error ***do not flash that backup***!
+
+## Uninstalling Unlaunch from your NAND backup (optional)
+Follow this if you dumped your NAND backup after you installed Unlaunch and you would like to uninstall Unlaunch from your system.
+1. Download the latest version of the [Unlaunch installer](https://problemkaputt.de/unlaunch.zip)
+1. Extract `UNLAUNCH.DSI` from `unlaunch.zip`
+1. Launch `UNLAUNCH.DSI` in no$gba and start it from the Game Card slot
+- This should start the Unlaunch installer, which looks similar to to the Unlaunch Filemenu
+4. Choose `Uninstall`
+4. Once complete, choose `Power down`
+4. Launch any Nintendo DS ROM again, and ensure your DSi menu loads and is working properly
 
 ## Flashing your NAND backup (Software)
 

--- a/_pages/en_US/troubleshooting.md
+++ b/_pages/en_US/troubleshooting.md
@@ -29,7 +29,7 @@ The developer of Unlaunch (nocash) has intentionally patched out the background 
 
 Try ejecting the SD card and powering the console on again. If it still only shows a black screen, you may need to flash your NAND via a [hardmod](https://wiki.ds-homebrew.com/ds-index/hardmod).
 
-### After installing Unlaunch, I'm stuck booting into an application
+### After installing Unlaunch, I'm stuck booting into an application or the Unlaunch Filemenu
 
 This was likely caused by choosing the wrong app for the `NO BUTTON` option in Unlaunch. Hold <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while starting the console, go to `OPTIONS`, and set `NO BUTTON` to whatever your preference is.
 
@@ -37,7 +37,7 @@ This was likely caused by choosing the wrong app for the `NO BUTTON` option in U
 
 If Unlaunch displays `Clusters too large`, `Bad VBR`, `Bad MBR`, or doesn't display any applications while the SD card is inserted, your SD card likely wasn't formatted correctly. Re-follow [SD Card Setup](sd-card-setup).
 
-## TWiLight Menu++  troubleshooting
+## TWiLight Menu++
 
 For general TWiLight Menu++ troubleshooting, see its [FAQ & Troubleshooting](https://wiki.ds-homebrew.com/twilightmenu/faq) page on the DS-Homebrew Wiki.
 

--- a/_pages/en_US/troubleshooting.md
+++ b/_pages/en_US/troubleshooting.md
@@ -21,7 +21,7 @@ If the issue persists, try this:
 1. Unmount `twl_main.img`, then unmount the NAND backup in ninfs
 If the NAND was saved, follow [Restoring NAND](restoring-nand) and continue with [Installing Unlaunch](installing-unlaunch).
 
-### There is no audio or boot splash when launching "LAUNCHER" using Unlaunch
+### There is no audio or boot splash when launching "Launcher" using Unlaunch
 
 The developer of Unlaunch (nocash) has intentionally patched out the background audio and boot-splash by default. You can regain these effects by [reinstalling Unlaunch](/installing-unlaunch) using TWiLight Menu++, or by using [hiyaCFW](https://wiki.ds-homebrew.com/hiyacfw/installing).
 

--- a/_pages/en_US/uninstalling-unlaunch.md
+++ b/_pages/en_US/uninstalling-unlaunch.md
@@ -7,17 +7,14 @@ title: Uninstalling Unlaunch
 
 **WARNING:** An uninstall of Unlaunch may brick your Nintendo DSi. Here are some cases on why you may want to uninstall Unlaunch but with solutions that don't require uninstalling.
 
-- **The Unlaunch Background is scary:** [Reinstall Unlaunch](../installing-unlaunch) using the new instructions. They now contain instructions on how to change the background
-- **I'm having an issue with Unlaunch or my console after installing it:** The [Troubleshooting](../troubleshooting#unlaunch) page will explain how to fix many issues you have
+- **The Unlaunch Background is scary:** [Reinstall Unlaunch](installing-unlaunch) using the new instructions. They now contain instructions on how to change the background
+- **I'm having an issue with Unlaunch or my console after installing it:** The [Troubleshooting](troubleshooting#unlaunch) page will explain how to fix many issues you may have
 
-To reduce the chances of bricking, make sure that you have not installed any non-legit DSiWare to your System NAND (the SDNAND redirection provided by hiyaCFW does not count), or have otherwise tampered with system files.
+To reduce the chances of bricking, make sure that you have not installed any illegitimate DSiWare to your NAND backup (the SDNAND redirection provided by hiyaCFW does not count), or have otherwise tampered with system files.
 {: .notice--warning}
 
-1. Download the latest version of [Unlaunch](https://problemkaputt.de/unlaunch.zip)
-1. Extract `UNLAUNCH.DSI` from the Unlaunch archive and copy it anywhere your SD card
-1. Power on your console while holding <kbd class="face">A</kbd> and <kbd class="face">B</kbd>
-   - This should launch the Unlaunch Filemenu
-1. Select the `UNLAUNCH.DSI` file you just downloaded
-1. Select `Uninstall`
-   - It will say that the system will become "useless", which is the developer's (nocash) way of saying it will be back to the way it was before Unlaunch was installed
-1. When completed, reboot (power down and power back on) your system in order to verify Unlaunch uninstalled properly
+When uninstalling Unlaunch, you should **NOT** use its built-in uninstaller, because there is a chance that it will brick the console. Please see below for information on uninstalling it properly.
+{: .notice--warning}
+
+Once you have reviewed the above information, proceed to [Restoring a NAND Backup](restoring-nand). This will guide you through flashing the NAND backup you made during [Dumping NAND](dumping-nand).
+- If you are no longer in possession of a NAND backup from before you installed Unlaunch, follow [Dumping NAND](dumping-nand) and proceed with [Restoring a NAND Backup](restoring-nand). There are instructions for users who have Unlaunch installed on their NAND backup

--- a/_pages/en_US/uninstalling-unlaunch.md
+++ b/_pages/en_US/uninstalling-unlaunch.md
@@ -7,9 +7,8 @@ title: Uninstalling Unlaunch
 
 **WARNING:** An uninstall of Unlaunch may brick your Nintendo DSi. Here are some cases on why you may want to uninstall Unlaunch but with solutions that don't require uninstalling.
 
-- **The Unlaunch Background is scary:** Reinstall Unlaunch using [the new instructions](/installing-unlaunch). They now contain instructions on how to change the background
-- **There is no Splash screen and the music is missing:** Reinstall Unlaunch using [the new instructions](/installing-unlaunch). They now contain mitigation instructions
-- **My system is bricked:** This page isn't for you then, as it requires a working system in order to uninstall Unlaunch
+- **The Unlaunch Background is scary:** [Reinstall Unlaunch](../installing-unlaunch) using the new instructions. They now contain instructions on how to change the background
+- **I'm having an issue with Unlaunch or my console after installing it:** The [Troubleshooting](../troubleshooting#unlaunch) page will explain how to fix many issues you have
 
 To reduce the chances of bricking, make sure that you have not installed any non-legit DSiWare to your System NAND (the SDNAND redirection provided by hiyaCFW does not count), or have otherwise tampered with system files.
 {: .notice--warning}


### PR DESCRIPTION
Changes:
- Edit [Uninstalling Unlaunch](https://dsi.cfw.guide/uninstalling-unlaunch) to redirect to NAND backup flashing instead of using the built-in uninstaller, as well as simply alternatives/solutions
   - Fixes #100 
- Add instructions for uninstalling Unlaunch from a NAND backup in no$gba
   - For users who don't have a NAND backup from before Unlaunch 
- Some minor changes to Troubleshooting page
- Add "What happened to the hiyaCFW installation guide?" to FAQ
- Update Unlaunch installation page for nds-bootstrap 0.48.0
   - nds-bootstrap can now launch DSiWare without Unlaunch