### PR TITLE
config: do not render txt files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -169,7 +169,7 @@ keep_files:
   - .git
   - .svn
 encoding: "utf-8"
-markdown_ext: "markdown,mkdown,mkdn,mkd,md,txt"
+markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 
 # Conversion


### PR DESCRIPTION
Having this enabled renders `robots.txt` as HTML. The guide doesn't render txt files anyway, so I don't see why we should keep it enabled.