### PR TITLE
Link to 'what is the root' image

### DIFF
--- a/docs/alternate-exploits.md
+++ b/docs/alternate-exploits.md
@@ -37,6 +37,12 @@ petit-compwner will not be usable for the purpose of working around Memory Pit, 
 1. Download the latest version of [Flipnote Lenny](https://davejmurphy.com/%CD%A1-%CD%9C%CA%96-%CD%A1/)
 1. Copy the `private` folder from the Flipnote Lenny archive to the root of your SD card
 
+::: tip
+
+Unsure what the SD "root" is? [See this image](https://media.discordapp.net/attachments/489307733074640926/756947922804932739/wherestheroot.png)
+
+:::
+
 You may now eject your SD card and put it into your Nintendo DSi.
 
 ### Section II - Exploiting on the Nintendo DSi

--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -48,6 +48,12 @@ For an understanding on why we're doing this, please see the [FAQ](faq.html#what
 1. Extract the `_nds` folder from `TWiLightMenu-DSi.7z` to the root of your SD card
 1. Extract the `BOOT.NDS` file from `TWiLightMenu-DSi.7z` to the root of your SD card
 
+::: tip
+
+Unsure what the SD "root" is? [See this image](https://media.discordapp.net/attachments/489307733074640926/756947922804932739/wherestheroot.png)
+
+:::
+
 ## Section II - Launching the exploit
 1. Ensure your SD card is inserted into your Nintendo DSi
 1. Boot your Nintendo DSi and launch the Nintendo DSi Camera application


### PR DESCRIPTION
Puts tip boxes linking to the 'What is root of the SD Card?' image below the first two mentions of the SD root (memory pit and alternate exploits)

(this one)
![wherestheroot.png](https://media.discordapp.net/attachments/489307733074640926/756947922804932739/wherestheroot.png)