### PR TITLE
Update dumping instructions for GodMode9i v3.2.0

### DIFF
--- a/docs/dsiware-backups.md
+++ b/docs/dsiware-backups.md
@@ -8,7 +8,7 @@ title: DSiWare Backups
 
 ## Nintendo DSi - Instructions
 
-### Section 1 - Dumping the DSiware
+### Section I - Dumping the DSiware
 1. Launch GodMode9i
 1. Press <kbd>START</kbd> to open the START Menu
 1. Select `Title manager...`

--- a/docs/dsiware-backups.md
+++ b/docs/dsiware-backups.md
@@ -8,31 +8,17 @@ title: DSiWare Backups
 
 ## Nintendo DSi - Instructions
 
-### Section I - Identifying the desired DSiWare
-1. Launch GodMode9i and select `[nand:] SYSNAND`
-1. Navigate to the `title` folder
-1. Choose the folder according to whichever category you're looking for
-   - `00030004`: Standard DSiWare
-   - `00030005`: Pre-installed Fun Tools
-   - `0003000f`: System Data (non-DSiWare files, can't be run)
-   - `00030015`: System Base Tools
-   - `00030017`: Launcher
-1. Once you have chosen which type of DSiWare you would like to extract, enter a subfolder, and then enter `content`
-1. There should now be an `.app` file visible. Select the file, and choose `Show NDS file info`. This will tell you if it's the DSiWare that you are looking for
-   - If it is not the DSiWare title that you were looking for, continue searching in other folders until you find it
-   - Files in `0003000f` cannot have their NDS file info viewed because they are not launchable DSiWare and do not contain a valid banner
+### Section 1 - Dumping the DSiware
+1. Launch GodMode9i
+1. Press <kbd>START</kbd> to open the START Menu
+1. Select `Title manager...`
+   - If this isn't shown, ensure you have your SD card and NAND mounted. If loading from hiyaCFW reload from somewhere else
+1. Select the title you want to dump
+1. Select what you want to dump
+1. Repeat steps 4-5 for all of the DSiWare you wish to dump
 
-### Section II - Extracting the DSiWare
-1. Highlight the `.app` file, then press <kbd class="face">Y</kbd> to add it to the clipboard
-1. Navigate your SD card to the directory where you'd like to place the dumped DSiWare title
-1. Press <kbd class="face">Y</kbd> again to paste the DSiWare title in the directory you are currently navigating
-   - You can change the name of the file after pasting it by pressing <kbd class="face">X</kbd> while holding <kbd class="R">R</kbd>
-   - Repeat this for all files you wish to copy to the same directory
+::: tip
 
-You should now see the DSiWare title in TWiLight Menu++ or the Unlaunch Filemenu.
+The dumped DSiWare will be found in `sd:/gm9i/out`.
 
-### Section III - Extracting the save file (optional)
-1. In the same folder as `content` for your specified DSiWare, there will be a folder named `data`
-1. Inside the `data` folder is the save file. Copy this file to your SD card in the same way you did for the DSiWare title itself
-   - Unlaunch and nds-bootstrap use the `.pub` and `.prv` file extensions for DSiWare save files. If your DSiWare save file was originally titled `public.sav`, use the `.pub` extension, and if the save file was originally titled `private.sav`, use the `.prv` extension
-   - If you wish to use the DSiWare save file with TWiLight Menu++, make sure to place it in the `saves` folder at the location of your ROM
+:::

--- a/docs/dumping-game-cards.md
+++ b/docs/dumping-game-cards.md
@@ -21,15 +21,12 @@ Using a Windows, Linux or macOS device? Use [Lazy DSi Downloader](lazy-dsi-downl
 1. Extract `GodMode9i.nds` from the GodMode9i archive and place it anywhere on your SD card
 
 ### Section II - Nintendo DSi instructions
-1. Power on your console while holding <kbd class="face">A</kbd> and <kbd class="face">B</kbd>
-   - This should launch the Unlaunch Filemenu
-1. Launch GodMode9i from the Unlaunch Filemenu
+1. Launch GodMode9i
 1. Ensure the Game Card is inserted into the console
 1. Select the "NDS GAMECARD" option in GodMode9i
-1. Select if you want the padding or not:
-   - Full: Padding included
-   - Trim: Padding removed
-1. Repeat steps 3-5 for all Game Cards you wish to dump
+1. Select what you want to dump
+   - The "Trimmed" options for the ROM will dump a smaller file that can save SD card space, however they won't work for most patches such as ROM hacks
+1. Repeat steps 2-4 for all Game Cards you wish to dump
 
 ::: tip
 


### PR DESCRIPTION
Do not merge until the next release of GodMode9i comes out, just making this in preparation for it since game card dumping has changed.

Updates the game card dumping instructions to better reflect how it'll work in the next GodMode9i update, could maybe be explained better, this is what the new menu looks like:
![dump menu](https://user-images.githubusercontent.com/41608708/148635894-2282d9c2-67df-4597-9ed6-2a1afa591627.png)

Also changes it from telling you to launch from Unlaunch to just launch it, loading from TWiLight works fine too, honestly better as NitroFS works.