### PR TITLE
Add a step for removing DCIM folder.

### DIFF
--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -46,6 +46,10 @@ Using a Windows, Linux or macOS device? Use [Lazy DSi Downloader](lazy-dsi-downl
 1. If there is already a `pit.bin` file in that path, create a backup of that file
 1. Place the Memory Pit `pit.bin` file in this folder
 
+::: warning
+
+If you previosly used your SD card to store photos, back up the `sd:/DCIM` folder and remove it from the SD card. You can restore it later, but attempting to launch the exploit may fail if the folder is still present in that moment.
+
 ::: tip
 
 For an understanding on why we're doing this, please see the [FAQ](faq.html#what-functionality-will-i-lose-by-modding-my-system).
@@ -80,7 +84,7 @@ If the top screen turns green, you do not have TWiLight Menu++'s `BOOT.NDS` on t
 
 ::: warning
 
-If you enter the SD card camera album and nothing unusual happens, ensure that you downloaded the correct version of Memory Pit for your version and region, and placed it into the correct folder on your SD card.
+If you enter the SD card camera album and nothing unusual happens, ensure that you downloaded the correct version of Memory Pit for your version and region, and placed it into the correct folder on your SD card. Also ensure that the `DCIM` does not exist on your SD card.
 
 :::
 

--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -45,10 +45,7 @@ Using a Windows, Linux or macOS device? Use [Lazy DSi Downloader](lazy-dsi-downl
    - If it does not exist, please create the individual folders
 1. If there is already a `pit.bin` file in that path, create a backup of that file
 1. Place the Memory Pit `pit.bin` file in this folder
-
-::: warning
-
-If you previosly used your SD card to store photos, back up the `sd:/DCIM` folder and remove it from the SD card. You can restore it later, but attempting to launch the exploit may fail if the folder is still present in that moment.
+1. If there's a folder named `DCIM` in the root of your SD card, make a back up of it so you don't lose the pictures inside, and then remove it from the SD card 
 
 ::: tip
 


### PR DESCRIPTION
Some users have encountered a situation where having a DCIM folder with pictures on the SD card makes the Memory Pit exploit to fail.
I think there sholud be indications to back up this folder and remove it so the exploit launches successfully.