### PR TITLE
Update lazy-dsi-downloader.md

### DIFF
--- a/docs/lazy-dsi-downloader.md
+++ b/docs/lazy-dsi-downloader.md
@@ -9,17 +9,16 @@ title: Lazy DSi Downloader
 1. Turn on your Nintendo DSi
 1. Launch into the Nintendo DSi Camera Application
 
-If at this point you get a tutorial and crash when trying to follow it, then you cannot use Memory Pit. Please see [Alternate Exploits](alternate-exploits.html) instead.
+If at this point you get a tutorial and crash when trying to follow it, then you cannot use Memory Pit.
 
 ## Setup Guide
 
-1. If you are on Windows, download & install the latest version of [7-Zip](https://www.7-zip.org/download.html)
-   - This will not work with any other archive extractor tool you own, such as WinRAR. The Lazy DSi File Downloader relies on 7-Zip itself, and not a general archive extractor
 1. Download the latest release of [Lazy DSi File Downloader](https://github.com/yourkalamity/lazy-dsi-file-downloader/releases) for your OS
-1. Launch it via the instructions listed in the release page
+1. Launch it via the instructions for your operating system listed in the release page
 1. Hit the Next button
    - The intro text isn't mandatory to read
-1. If you have got a crash in your verification steps, toggle off the Memory Pit option
-1. Hit the check boxes for "Download GodMode9i" and "Download Unlaunch"
-   - Feel free to select any of the other homebrew applications in `Additional homebrew...`, but this is not mandatory
+1. If your Nintendo DSi crashed during the verification steps above, toggle off the Memory Pit option
+   - As for which exploit to use, please visit our [Alternative Exploits](alternate-exploits.html) page
+1. Hit the check boxes for "Download latest GodMode9i version?"
+   - Feel free to select any of the other homebrew applications in `Click to add Additional homebrew...`, but this is not mandatory
 1. Wait for everything to download, then hit Finish


### PR DESCRIPTION
- Remove mention of 7-ZIP
- Clarify where the crash originates
- Move alternative exploits mention to where its relevant, so that people don't think that they cannot follow the Lazy DSi Installer steps if they do not have the ability to use Memory Pit

I messed up and removed the link, so if anyone can add it back thatd be great

Also, must have the approval of Kalam.