### PR TITLE
sd-card-setup: remove all mentions of Nintendo DSi to make page generic

### DIFF
--- a/docs/sd-card-setup.md
+++ b/docs/sd-card-setup.md
@@ -2,7 +2,7 @@
 title: SD Card Setup
 ---
 
-This page is for preparing your SD card for your Nintendo DSi. In the process, we'll format the SD card to a format suitable for the Nintendo DSi and check the card for errors.
+This page is for preparing your SD card for your device. In the process, we'll format the SD card and check the card for errors.
 
 ::: danger
 


### PR DESCRIPTION
Functionally nothing has changed aside from simply removing anything that may point to the guide saying it's particular for the DSi. I end up using this page all the time to format flashcart SDs as well.

If someone has a better way of handling this please review.