### PR TITLE
Recommend uninstalling Unlaunch in no$gba over pre-Unlaunch backup

### DIFF
--- a/docs/restoring-nand.md
+++ b/docs/restoring-nand.md
@@ -65,7 +65,7 @@ Follow this if you dumped your NAND backup after you installed Unlaunch and you 
 1. Once complete, choose `Power down`
 1. Launch any Nintendo DS ROM again, and ensure your DSi menu loads and is working properly
 
-If no$gba shows any kind of error instead of loading the DSi menu, ***do not flash that backup***! If you have an older NAND backup you may want to try using that instead.
+If no$gba shows any kind of error instead of loading the DSi menu, ***do not flash that backup***! If you have an older NAND backup you may want to try using that instead. Do **not** try to uninstall Unlaunch using its uninstaller on the console, it is extremely likely doing so will brick your DSi.
 
 ## Flashing your NAND backup (Software)
 

--- a/docs/restoring-nand.md
+++ b/docs/restoring-nand.md
@@ -65,6 +65,8 @@ Follow this if you dumped your NAND backup after you installed Unlaunch and you 
 1. Once complete, choose `Power down`
 1. Launch any Nintendo DS ROM again, and ensure your DSi menu loads and is working properly
 
+If no$gba shows any kind of error instead of loading the DSi menu, ***do not flash that backup***! If you have an older NAND backup you may want to try using that instead.
+
 ## Flashing your NAND backup (Software)
 
 ::: danger

--- a/docs/uninstalling-unlaunch.md
+++ b/docs/uninstalling-unlaunch.md
@@ -21,9 +21,10 @@ To reduce the chances of bricking, make sure that you have not installed any ill
 
 ::: warning
 
-When uninstalling Unlaunch, you should **NOT** use its built-in uninstaller, because there is a chance that it will brick the console. Please see below for information on uninstalling it properly.
+When uninstalling Unlaunch, you should **NOT** use its built-in uninstaller directly on your console as there is a chance that it will brick the console. Please see below for information on uninstalling it properly.
 
 :::
 
-Once you have reviewed the above information, proceed to [Restoring a NAND Backup](restoring-nand.html). This will guide you through flashing the NAND backup you made during [Dumping NAND](dumping-nand.html).
-- If you are no longer in possession of a NAND backup from before you installed Unlaunch, follow [Dumping NAND](dumping-nand.html) and proceed with [Restoring a NAND Backup](restoring-nand.html). There are instructions for users who have Unlaunch installed on their NAND backup
+Once you have reviewed the above information, follow the [Dumping NAND](dumping-nand.html) instructions to make a new NAND bacup, then proceed to [Restoring a NAND Backup](restoring-nand.html). This will guide you through uninstalling Unlaunch from the NAND backup and flashing that to your console.
+
+If you are not able to use no$gba or get an error after uninstalling Unlaunch in no$gba it is also possible to flash a NAND backup made prior to installing Unlaunch if you still have one, however it is recommended to try using a NAND backup that previously had Unlaunch first. This will make recovery significantly easier in the case of a brick requiring a hardmod as Unlaunch leaves the no$gba footer embedded in the NAND even when uninstalled.


### PR DESCRIPTION
This changes the Uninstalling Unlaunch page to recommend making a new NAND backup and uninstalling Unlaunch using no$gba over flashing a pre-Unlaunch backup if possible.

This allows the very good safety precation of Unlaunch leaving the no$gba footer in the NAND, thus removing the need to bruteforce it in the event that the console bricks and its NAND backups were lost later down the line.

Flashing a pre-Unlaunch backup is still suggested if you can't use no$gba or the no$gba uninstallation fails, however unless that's the case I think it would be a much better idea to do the proper uninstall on a new backup.