### PR TITLE
Remove Launcher Patches step

### DIFF
--- a/docs/installing-unlaunch.md
+++ b/docs/installing-unlaunch.md
@@ -46,8 +46,6 @@ Using a Windows, Linux or macOS device? Use [Lazy DSi Downloader](lazy-dsi-downl
 1. Hit <kbd class="l">L</kbd> / <kbd class="r">R</kbd> or <kbd class="face">X</kbd> / <kbd class="face">Y</kbd> until you reach the `Unlaunch settings` page
 1. If you want to change Unlaunch's background image, select `Background` and choose the one you want
    - If you want to create your own Unlaunch background, see the [DS-Homebrew Wiki page](https://wiki.ds-homebrew.com/twilightmenu/custom-unlaunch-backgrounds)
-1. If you want the Health and Safety screen and DSi Menu music and sounds when using the official Nintendo DSi Menu, then set `Launcher Patches` to `Off`
-   - This will also keep the region locking and card whitelist, meaning that some flashcards won't be usable from the DSi Menu
 1. Exit TWiLight Menu++ Settings
 1. In the file navigation menu, launch `Unlaunch DSi Installer`
 1. Select the "install now" option


### PR DESCRIPTION
To go with DS-Homebrew/TWiLightMenu#2070, this removes the Launcher Patches step as the new default is good for most people.

Do not merge until the next TWiLight Menu++ release.