### PR TITLE
Fixed a spelling error on the uninstalling unlaunch page.

### DIFF
--- a/docs/uninstalling-unlaunch.md
+++ b/docs/uninstalling-unlaunch.md
@@ -25,6 +25,6 @@ When uninstalling Unlaunch, you should **NOT** use its built-in uninstaller dire
 
 :::
 
-Once you have reviewed the above information, follow the [Dumping NAND](dumping-nand.html) instructions to make a new NAND bacup, then proceed to [Restoring a NAND Backup](restoring-nand.html). This will guide you through uninstalling Unlaunch from the NAND backup and flashing that to your console.
+Once you have reviewed the above information, follow the [Dumping NAND](dumping-nand.html) instructions to make a new NAND backup, then proceed to [Restoring a NAND Backup](restoring-nand.html). This will guide you through uninstalling Unlaunch from the NAND backup and flashing that to your console.
 
 If you are not able to use no$gba or get an error after uninstalling Unlaunch in no$gba it is also possible to flash a NAND backup made prior to installing Unlaunch if you still have one, however it is recommended to try using a NAND backup that previously had Unlaunch first. This will make recovery significantly easier in the case of a brick requiring a hardmod as Unlaunch leaves the no$gba footer embedded in the NAND even when uninstalled.


### PR DESCRIPTION
Replaced "bacup" with "backup".