### PR TITLE
Added a warning about taking pictures to the SD card with the memory pit exploit installed.

### DIFF
--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -60,13 +60,13 @@ If you enter the SD card camera album and nothing unusual happens, ensure that y
 
 :::
 
-You can now use TWiLight Menu++! First, it will ask you to select your language and region. These do not need to match your console's language or region so set them to whichever you prefer. Next it's recommended to continue on and make a NAND backup. This can potentially be used to save your console if anything bad happens in the future.
-
 ::: warning
 
 If you take photos on the SD card with the Memory Pit exploit on it, the exploit will stop working properly and you will have to copy it onto the SD card again. You will lose the photos you had taken on the SD card when you copy it again. If you do take photos and save them to the SD card, your DSi will freeze when you try to view the photos. Use another SD card or System Memory to take photos instead.
 
 :::
+
+You can now use TWiLight Menu++! First, it will ask you to select your language and region. These do not need to match your console's language or region so set them to whichever you prefer. Next it's recommended to continue on and make a NAND backup. This can potentially be used to save your console if anything bad happens in the future.
 
 ::: tip
 

--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -61,7 +61,7 @@ If you enter the SD card camera album and nothing unusual happens, ensure that y
 
 ::: warning
 
-If you take photos on the SD card with the Memory Pit exploit on it, the exploit will stop working properly and you will have to copy it onto the SD card again. You will lose the photos you had taken on the SD card when you copy it again. If you do take photos and save them to the SD card, your DSi will freeze when you try to view the photos. Use another SD card or System Memory to take photos instead.
+Taking photos with the Memory Pit exploit on your SD card will cause the exploit to stop working properly and you will have to copy it over again.
 
 :::
 

--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -34,7 +34,8 @@ If you don't plan on installing Unlaunch and have either the DSi Browser or Flip
       - For clarification, create the `private` folder, open it, create the `ds` folder, open it, and so on
 1. Inside the `484E494A` folder, if there is already a `pit.bin` file, rename it to `tip.bin`
 1. Place the Memory Pit `pit.bin` file in the `484E494A` folder
-1. If there's a folder named `DCIM` in the root of your SD card, make a back up of it so you don't lose the pictures inside, and then remove it from the SD card 
+1. If there's a folder named `DCIM` in the root of your SD card, make a back up of it so you don't lose the pictures inside, and then remove it from the SD card
+1. 
 
 
 ## Section III - Launching the exploit
@@ -60,6 +61,12 @@ If you enter the SD card camera album and nothing unusual happens, ensure that y
 :::
 
 You can now use TWiLight Menu++! First, it will ask you to select your language and region. These do not need to match your console's language or region so set them to whichever you prefer. Next it's recommended to continue on and make a NAND backup. This can potentially be used to save your console if anything bad happens in the future.
+
+::: warning
+
+If you take photos on the SD card with the Memory Pit exploit on it, the exploit will stop working properly and you will have to copy it onto the SD card again. You will lose the photos you had taken on the SD card when you copy it again. If you do take photos and save them to the SD card, your DSi will freeze when you try to view the photos. Use another SD card or System Memory to take photos instead.
+
+:::
 
 ::: tip
 

--- a/docs/launching-the-exploit.md
+++ b/docs/launching-the-exploit.md
@@ -35,7 +35,6 @@ If you don't plan on installing Unlaunch and have either the DSi Browser or Flip
 1. Inside the `484E494A` folder, if there is already a `pit.bin` file, rename it to `tip.bin`
 1. Place the Memory Pit `pit.bin` file in the `484E494A` folder
 1. If there's a folder named `DCIM` in the root of your SD card, make a back up of it so you don't lose the pictures inside, and then remove it from the SD card
-1. 
 
 
 ## Section III - Launching the exploit


### PR DESCRIPTION
I took pictures with it still on my SD thinking it would be fine. When I went to do the exploit to get into Twilight, it either hung my DSi or did some weird glitchy thing. Feel free to reject this pull if I was wrong and it was something else that caused it.