### PR TITLE
Fix missing headers within tabs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -48,6 +48,7 @@ module.exports = {
 		[ 'link', { rel: 'mask-icon', color: '#2E3440', href: '/assets/favicon/safari-pinned-tab.svg' } ],
 		[ 'link', { rel: 'shortcut icon', href: '/assets/favicon/favicon.ico' } ],
 		[ 'link', { rel: 'stylesheet', href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css' } ],
+		[ 'link', { rel: 'stylesheet', href: '/assets/stylesheet/style-override.css' } ],
 		[ 'meta', { name: 'msapplication-TileColor', content: '#2E3440' } ],
 		[ 'meta', { name: 'msapplication-TileImage', content: '/assets/favicon/mstile-144x144.png' } ],
 		[ 'meta', { name: 'msapplication-config', content: '/assets/favicon/browserconfig.xml' } ],

--- a/docs/.vuepress/public/assets/stylesheet/style-override.css
+++ b/docs/.vuepress/public/assets/stylesheet/style-override.css
@@ -1,0 +1,4 @@
+.tab-container .tab .header-anchor {
+  display: inherit;
+  pointer-events: none;
+}


### PR DESCRIPTION
Fix missing headers within tabs

https://dsi.cfw.guide/sd-card-setup.html
People simply can't find section III when sd card is 32G or less

maybe this can be changed directly in the common theme, but then it'll also affect style of ios.cfw.guide and maybe some other guide, so not sure if that's feasible (and this is pretty much dsi guide only issue due to different header style)