### PR TITLE
Update unlaunch install and uninstall sections

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -41,10 +41,9 @@ To check, press the <kbd class="face">POWER</kbd> button and immediately hold th
 
 ## Section III - Memory Pit
 
-Memory Pit is an exploit utilizing the DSi Camera, compatible with all firmware versions. Optionally, this exploit can be used to install Unlaunch.
+Memory Pit is an exploit utilizing the DSi Camera, compatible with all firmware versions.
 
-There is a very minor risk of **bricking** your console when installing Unlaunch, so if this is a concern, use an [alternate exploit](alternate-exploits.html) instead, or proceed with the guide normally, but avoid installing Unlaunch.     
-Keep in mind that if you don't install Unlaunch, homebrew compatibility will be somewhat limited if you only use Memory Pit.
+If using the exploit without installing Unlaunch, compatibility with some homebrews could be limited. If you encounter issues with DSi homebrews, you can return to this guide and set up an [alternate exploit](alternate-exploits.html) instead.
 
 ::: tip
 

--- a/docs/installing-unlaunch.md
+++ b/docs/installing-unlaunch.md
@@ -1,22 +1,22 @@
 # Installing Unlaunch
 
-You are about to install Unlaunch, a bootcode exploit which gets installed onto the DSi console itself, allowing full control of the console on boot, and as a result, allows homebrew applications full access to the hardware without restrictions from DSi system apps or DSiWare titles.
+You are about to install Unlaunch, a permanent bootcode exploit which gets installed onto the DSi console itself, allowing full control of the console on boot, and as a result, allows homebrew applications full access to the hardware without restrictions from DSi system apps or DSiWare titles.
 
-::: warning
+::: danger
 
-If you do not have access to a PC, or if your PC is running ChromeOS, then please do not install Unlaunch. A PC (running Windows, Linux, or macOS) is required in order to fix some issues that may occur after installing Unlaunch.
+If you have not yet done so, please follow [Dumping NAND](dumping-nand.html). A NAND backup + [ntrboot](https://wiki.ds-homebrew.com/ds-index/ntrboot) (or a [hardmod](https://wiki.ds-homebrew.com/ds-index/hardmod), provided you know how to solder) would allow you to restore this backup in case the console gets bricked afterwards.
 
 :::
 
 ::: danger
 
-If you have not yet done so, please follow [Dumping NAND](dumping-nand.html). While the chances are slim, Unlaunch can accidentally brick your Nintendo DSi. A NAND backup + [hardmod](https://wiki.ds-homebrew.com/ds-index/hardmod) would allow you to restore this backup, provided you know how to solder.
+Installing or uninstalling Unlaunch, while safe, writes to the console's NAND, so there's a small chance to brick your console!
 
 :::
 
 ::: warning
 
-Make sure your console is charged when following this process. A sudden power loss could result in serious damage.
+If you do not have access to a PC, or if your PC is running ChromeOS, then please do not install Unlaunch. A PC (running Windows, Linux, or macOS) is required to ensure the SD Card used is formatted in a way compatible with Unlaunch.
 
 :::
 
@@ -36,15 +36,16 @@ Unlaunch is not compatible with Nintendo DSi development consoles.
 1. Open the menu you have installed (**TW**i**L**ight Menu++ or akmenu-next)
     - If this is your first time installing Unlaunch, relaunch the menu through the [exploit that you used](launching-the-exploit.html)
 	- If you have not installed either of those menus, and you are looking to install hiyaCFW, start the [exploit that you used](launching-the-exploit.html) in order to start GodMode9**i**, then open the SD card (listed as `sd:`)
-    - If you have already installed Unlaunch and are looking to update it, hold <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while booting and select the option in where `BOOT.NDS` is shown at the end of the path on the bottom screen
+    - If you have already installed Unlaunch and are looking to update it, hold <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while booting
 1. In the menu where the icons are listed, launch `Safe Unlaunch installer` (listed as `unlaunch-installer.dsi` depending on which menu is used and/or how it's displayed)
     - If using GodMode9**i**, select `Boot file (Direct)` after selecting `unlaunch-installer.dsi`
 1. Press the <kbd class="face">A</kbd> button after the `WARNING` message appears
     - If the battery LED is red, it'll tell you to plug in the console. Select `Yes` to continue after plugging it in
-1. If Unlaunch is already installed, select the `Uninstall unlaunch` or `Restore launcher tmd` option, and press <kbd class="face">A</kbd> once it's done
 1. If you want to change the default background, select `[Custom background]` and press <kbd class="face">A</kbd> to select the one you want to use
     - Three custom backgrounds are included, but you can add more into a folder called `backgrounds` on the SD card root (create the folder if it doesn't exist)
 1. If you want to keep both the DSi splash (with health and safety message) and the sound in the DSi system menu, select `Enable sound and splash` and press <kbd class="face">A</kbd> to turn it on
+1. If Unlaunch is already installed, select the `Uninstall unlaunch` or `Restore launcher tmd` option, and press <kbd class="face">A</kbd> once it's done
+	- If you only want to **uninstall** Unlaunch, you can stop here
 1. Select the `Install unlaunch` option, and press the <kbd class="face">A</kbd> button
 1. Press the <kbd class="face">A</kbd> button once installation is done
 1. Press <kbd class="face">POWER</kbd> to reboot your system
@@ -81,7 +82,7 @@ This section is optional and only serves for keeping your SD card tidy of files 
 - Delete the `sd:/private/ds/app/484E494A/pit.bin` file from your SD card
 - Rename `tip.bin` back to `pit.bin`, and leave it intact
 - You can now restore the `DCIM` folder that was on the root of your SD card
-- Delete the `UNLAUNCH.DSI` file from your SD card
+- Delete the `unlaunch-installer.dsi` file from your SD card
 
 :::
 
@@ -92,6 +93,6 @@ This section is optional and only serves for keeping your SD card tidy of files 
     - `sd:/private/ds/app/4B475545/001` (USA)
     - `sd:/private/ds/app/4B475556/001` (Europe/Australia)
     - You can also delete the entire folders for the regions besides your own
-- Delete the `UNLAUNCH.DSI` file from your SD card
+- Delete the `unlaunch-installer.dsi` file from your SD card
 
 :::

--- a/docs/uninstalling-unlaunch.md
+++ b/docs/uninstalling-unlaunch.md
@@ -2,13 +2,14 @@
 
 ::: danger
 
-**Installing or uninstalling Unlaunch may randomly brick your console! You have been warned!**
+Installing or uninstalling Unlaunch, while safe, writes to the console's NAND, so there's a small chance to brick your console!
 
 :::
 
-**WARNING:** An uninstall of Unlaunch may brick your Nintendo DSi. Here are some cases on why you may want to uninstall Unlaunch but with solutions that don't require uninstalling.
+**WARNING:** While uninstalling Unlaunch is relatively safe, ther's still a small chance of bricking your Nintendo DSi. Here are some cases on why you may want to uninstall Unlaunch but with solutions that don't require uninstalling.
 
-- **The Unlaunch Background is scary:** [Reinstall Unlaunch](installing-unlaunch.html) using the new instructions. They now contain instructions on how to change the background
+- **I don't want to use a custom menu anymore and I don't like having the Unlaunch file menu show on boot:** You can follow the [Unlaunch post install steps](installing-unlaunch.html#section-iii-post-unlaunch-configuration) to have Unlaunch autoboot the DSi menu
+- **The Unlaunch Background is scary:** [Reinstall Unlaunch](installing-unlaunch.html) by selecting one of the available custom backgrounds
 - **I'm having an issue with Unlaunch or my console after installing it:** The [Troubleshooting](troubleshooting.html#unlaunch) page will explain how to fix many issues you may have
 
 ::: warning
@@ -17,12 +18,4 @@ To reduce the chances of bricking, make sure that you have not installed any ill
 
 :::
 
-::: warning
-
-When uninstalling Unlaunch, you should **NOT** use its built-in uninstaller directly on your console as there is a chance that it will brick the console. Please see below for information on uninstalling it properly.
-
-:::
-
-Once you have reviewed the above information, follow the [Dumping NAND](dumping-nand.html) instructions to make a new NAND backup, then proceed to [Restoring a NAND Backup](restoring-nand.html). This will guide you through uninstalling Unlaunch from the NAND backup and flashing that to your console.
-
-If you are not able to use no$gba or get an error after uninstalling Unlaunch in no$gba it is also possible to flash a NAND backup made prior to installing Unlaunch if you still have one, however it is recommended to try using a NAND backup that previously had Unlaunch first. This will make recovery significantly easier in the case of a brick requiring a hardmod as Unlaunch leaves the no$gba footer embedded in the NAND even when uninstalled.
+Once you have reviewed the above information, follow the [Dumping NAND](installing-unlaunch.html) instructions up to the uninstall part.


### PR DESCRIPTION
With the use of the new installer, the uninstall section can be streamlined to make the user directly use the installer rather than restoring the nand backup.
The unlaunch install part got slightly updated and reworded as well.
Also the initial section about Memory pit got slightly simplified, to make people always try memory pit first, and in case then move to another exploit.
The "brick risk" mentions got reduced since the new install method should be more brickproof and secure.