### PR TITLE
sd: fix sdFormatLinux command parameters

### DIFF
--- a/docs/sd-card-setup.md
+++ b/docs/sd-card-setup.md
@@ -84,7 +84,7 @@ mmcblk0     179:0    0   3,8G  0 disk
     - Make sure that you're targetting the **device**, `mmcblk0`, not the partition, `mmcblk0p1`
 1. Hit CTRL + C to exit the menu
 1. Navigate to where you have extracted sdFormatLinux
-1. Run `sudo ./sdFormatLinux -e trim /dev/(device name from above)` to format your SD card
+1. Run `sudo ./sdFormatLinux -f -e trim /dev/(device name from above)` to format your SD card
 
 ::: tip
 


### PR DESCRIPTION
SDXC cards currently do not work with the sdFormatLinux instructions provided. The partition type will be set to exFat, even if the actual partition is formatted to be Fat32. This doesn't cause issues with Unlaunch, but it does prevent DSi applications from being able to use the SD card.

This patch adds the `-f` flag to the sdFormatLinux parameters. This fixes the above issue as the partition type will be set to Fat32. The mkdosfs instructions are still required to format the card to Fat32 with 32KiB clusters -- though a patch could be made to sdFormatLinux to support this use case.