### PR TITLE
Technical Changes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,6 +7,8 @@ It is **not** recommended to update your DSi unless you know there are purchased
 - Older exploits are no longer possible to use, which may be required if you are unable use the recommended exploits
 - Flashcard compatibility is reduced, however this is bypassed if you install Unlaunch
 
+The only exception is if you are installing Unlaunch and your DSi is specifically on System Version 1.4.2, which due to a bug, causes Safe Unlaunch Installer to fail on that version and therefore requires updating your DSi console to 1.4.5.
+
 ## Which is the best exploit?
 Unlaunch is overall the best exploit for the DSi, with the only downside being that there is a minor brick risk on install. In general it's recommended to use Memory Pit to install Unlaunch. If you want to avoid any risk it's recommended to instead use Flipnote Lenny as it has fewer issues in homebrew than Memory Pit while being just as safe and simple to remove. Below is a list of the pros and cons of each exploit:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ It is **not** recommended to update your DSi unless you know there are purchased
 - Older exploits are no longer possible to use, which may be required if you are unable use the recommended exploits
 - Flashcard compatibility is reduced, however this is bypassed if you install Unlaunch
 
-The only exception is if you are installing Unlaunch and your DSi is specifically on System Version 1.4.2, which due to a bug, causes Safe Unlaunch Installer to fail on that version and therefore requires updating your DSi console to 1.4.5.
+The only exception is an Unlaunch installation on a DSi with System Version 1.4.2 – this version is currently unsupported by Safe Unlaunch Installer (due to a bug), and requires updating your DSi console to 1.4.5.
 
 ## Which is the best exploit?
 Unlaunch is overall the best exploit for the DSi, with the only downside being that there is a minor brick risk on install. In general it's recommended to use Memory Pit to install Unlaunch. If you want to avoid any risk it's recommended to instead use Flipnote Lenny as it has fewer issues in homebrew than Memory Pit while being just as safe and simple to remove. Below is a list of the pros and cons of each exploit:

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -8,12 +8,13 @@ We'll begin with downloading some homebrew tool(s), in preparation for the explo
 - An application that can extract archives, such as [7-Zip](https://www.7-zip.org/) (Windows), [The Unarchiver](https://apps.apple.com/us/app/the-unarchiver/id425424353) (macOS), or [ZArchiver](https://play.google.com/store/apps/details?id=ru.zdevs.zarchiver) (Chromebook)
     - We advise you to not use WinRAR, as it is known to break things
     - If you're using Windows 11, we also advise you to not use it's built-in extractor (Windows Explorer), as it'll cause an error saying that the filename is too long or not valid
+- A good quality name-brand SD card (or name-brand MicroSD with SD adapter). **This is important as you may encounter compatibility issues and loss of data using an off-brand or counterfeit SD card!** For more information, [please see this article](https://www.flashcarts.net/microsd-fakes) on fake MicroSD cards, the information it has also applies to full size SD cards.
 
 ## Section I - Prep Work
 
 ::: warning
 
-Ensure your SD card is [formatted correctly](sd-card-setup.html).
+Ensure your SD card is [formatted correctly with this guide](sd-card-setup.html). You may encounter compatibility problems with homebrew or an SD Card with the wrong filesystem by skipping this step.
 
 :::
 

--- a/docs/installing-akmenu-next.md
+++ b/docs/installing-akmenu-next.md
@@ -12,6 +12,12 @@
 1. Extract `nds-bootstrap.zip`
 1. Copy the *contents* of the files from the extracted `nds-bootstrap.zip` file to the `_nds` folder on your SD card
 
+::: tip
+
+If you want to play games from before the DS(i) (such as GBA and below) and/or use other additional features (known as plugins), see [Installing Plugins](https://coderkei.github.io/akmenu-next-docs/guides/plugins/).
+
+:::
+
 ### After installation
 
 Run the [exploit that you used](launching-the-exploit.html) to start dumpTool, and AKMenu-Next will then start.

--- a/docs/installing-unlaunch.md
+++ b/docs/installing-unlaunch.md
@@ -59,7 +59,7 @@ If Unlaunch is already installed and you are looking to update or uninstall Unla
 
 ## Section III - Installing/Updating Unlaunch
 
-1. Open the menu you have installed (**TW**i**L**ight Menu++ or akmenu-next)
+1. Open the menu you have installed (**TW**i**L**ight Menu++ or AKMenu-Next)
     - If this is your first time installing Unlaunch, relaunch the menu through the [exploit that you used](launching-the-exploit.html)
     - If you have already installed Unlaunch and are looking to update it, hold <kbd class="face">A</kbd> + <kbd class="face">B</kbd> while booting
 1. In the menu where the icons are listed, launch `Safe Unlaunch installer` (listed as `unlaunch-installer.dsi` depending on which menu is used and/or how it's displayed)
@@ -86,8 +86,11 @@ Currently, Unlaunch defaults to launching its Filemenu on boot, but this can be 
     - If nothing is listed, or if only the NAND contents are listed (even after scrolling down), then you'll need to [reformat the SD card](sd-card-setup.html)
 1. Navigate to `OPTIONS`, and look at the available options
     - <kbd class="face">A</kbd> + <kbd class="face">B</kbd> is hardcoded to launch into Unlaunch's menu, and as such cannot be changed
-    - The `NO BUTTON` and `BUTTON A / B / X / Y` options can be set however you like and will choose what your DSi loads at boot depending on which buttons are held. You can select any DSiWare, homebrew (including whichever menu you installed), the Slot-1 card, wifiboot, or Unlaunch's Filemenu
+    - The `NO BUTTON` (Which autoboots) and `BUTTON A / B / X / Y` options can be set however you like and will choose what your DSi loads at boot depending on which buttons are held. You can select any DSiWare, homebrew (including whichever menu you installed), the Slot-1 card, wifiboot, or Unlaunch's Filemenu
       - For the original DSi Menu, select `Launcher`
+      - For TWiLight Menu++, select `TWiLight Menu++` (Listed as `sdmc:/BOOT.NDS` on the bottom screen)
+      - For AKMenu-Next, select `AKMenu-Next` (Listed as `sdmc:/akmenu-next.dsi` on the bottom screen)
+      - For hiyaCFW, select `hiyaCFW` (Listed as `sdmc:/hiya.dsi` on the bottom screen)
     - `LOAD ERROR` is what your DSi will load if loading what you have set fails, such as the SD card not being inserted
 1. Select `SAVE & EXIT` to save your settings, then turn off your DSi
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,10 @@ If Unlaunch displays `Clusters too large`, `Bad VBR`, `Bad MBR`, or doesn't disp
 
 For general TWiLight Menu++ troubleshooting, see its [FAQ & Troubleshooting](https://wiki.ds-homebrew.com/twilightmenu/faq) page on the DS-Homebrew Wiki.
 
+## AKMenu-Next
+
+For AKMenu-Next troubleshooting, please see the [Troubleshooting Page](https://coderkei.github.io/akmenu-next-docs/guides/troubleshooting) and [FAQ](https://coderkei.github.io/akmenu-next-docs/guides/faq) page on the AKMenu-Next Documentation Website.
+
 ## Further assistance
 
 If you have encountered an issue that is not solved here, or one that persists despite the given solutions, ask for assistance in the [DS<sup>(i)</sup> Mode Hacking!](https://discord.gg/fCzqcWteC4) Discord server.


### PR DESCRIPTION
- Updated FAQ to state an update is only needed for 1.4.2 Users who want Unlaunch
- Added note to getting started page that advises the user to use a good quality name-brand card and not an off-brand or fake card, with a link to the flashcarts.net fake MicroSD guide
- Made the formatting guide box stand out a bit more to the user in the getting started page by stating possible compatibility issues if they skip it
- Added notes to the AKMenu-Next installation page about using Plugins, much like how the TWL++ page mentions using addons
- Changed some mentions of "akmenu-next" to "AKMenu-Next"
- Mentions where TWL++, AKMenu-Next and HiyaCFW can be found in post unlaunch config
- Added a link to AKMenu-Next troubleshooting page