### PR TITLE
Use stylehax v2 over the original stylehax

### DIFF
--- a/docs/launching-the-browser-exploit.md
+++ b/docs/launching-the-browser-exploit.md
@@ -18,11 +18,12 @@ We'll start by first launching our exploit. For the best Unlaunch-free experienc
 1. Type `opera:about`, and touch `Go` to load the page
 1. Touch the HOME icon
 1. Touch the `Go to Page` button
-1. Type `stylehax.net`, and touch `Go` to load the page
+1. Type `stylehax.net/v2`, and touch `Go` to load the page
+1. Touch the refresh button once the page has fully loaded
 
 ::: tip
 
-The exploit should take 21 seconds to take effect. If it takes longer than 30 seconds, then reboot, and try again.
+The exploit should take effect almost instantly. If this does not happen, reboot the console and try again.
 
 :::
 


### PR DESCRIPTION
stylehax v2 is the newer version of stylehax. It is *very* reliable in comparison (works every time for me) and will trigger just about instantly. I believe the guide should be updated to use it over the very unreliable, original implementation.